### PR TITLE
This makes the automation tree look more like a regular tree view 

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/Internal/TreeListViewItemsCollectionTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Internal/TreeListViewItemsCollectionTests.cs
@@ -643,6 +643,45 @@ public class TreeListViewItemsCollectionTests
         Assert.Null(treeListViewItemsCollection.GetParent(8));
     }
 
+    [Fact]
+    public void GetDirectChildrenIndexes_GetsExpectedChildrenIndexes()
+    {
+        //Arrange
+        ObservableCollection<string> boundCollection = new() { "0", "1", "2" };
+        TreeListViewItemsCollection treeListViewItemsCollection = new(boundCollection);
+        treeListViewItemsCollection.InsertWithLevel(2, "1_0", 1);
+        treeListViewItemsCollection.InsertWithLevel(3, "1_1", 1);
+        treeListViewItemsCollection.InsertWithLevel(4, "1_2", 1);
+        treeListViewItemsCollection.InsertWithLevel(5, "1_2_0", 2);
+        treeListViewItemsCollection.InsertWithLevel(6, "1_2_1", 2);
+        treeListViewItemsCollection.InsertWithLevel(7, "1_2_2", 2);
+
+        /*
+         * 0. 0
+         * 1. 1
+         * 2.  1_0
+         * 3.  1_1
+         * 4.  1_2
+         * 5.    1_2_0
+         * 6.    1_2_1
+         * 7.    1_2_2
+         * 8. 2
+         */
+
+
+        //Act/Assert
+        Assert.Empty(treeListViewItemsCollection.GetDirectChildrenIndexes(0));
+        Assert.Equal(new[] { 2, 3, 4 }, treeListViewItemsCollection.GetDirectChildrenIndexes(1));
+        Assert.Empty(treeListViewItemsCollection.GetDirectChildrenIndexes(2));
+        Assert.Empty(treeListViewItemsCollection.GetDirectChildrenIndexes(3));
+        Assert.Equal(new[] { 5, 6, 7 }, treeListViewItemsCollection.GetDirectChildrenIndexes(4));
+        Assert.Empty(treeListViewItemsCollection.GetDirectChildrenIndexes(5));
+        Assert.Empty(treeListViewItemsCollection.GetDirectChildrenIndexes(6));
+        Assert.Empty(treeListViewItemsCollection.GetDirectChildrenIndexes(7));
+        Assert.Empty(treeListViewItemsCollection.GetDirectChildrenIndexes(8));
+        
+    }
+
     private class TestableCollection<T> : ObservableCollection<T>
     {
         private int _blockCollectionChanges;

--- a/MaterialDesignThemes.Wpf/Automation/Peers/TreeListViewItemAutomationPeer.cs
+++ b/MaterialDesignThemes.Wpf/Automation/Peers/TreeListViewItemAutomationPeer.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Automation.Peers;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
 
 namespace MaterialDesignThemes.Wpf.Automation.Peers;
 
@@ -8,8 +9,36 @@ public class TreeListViewAutomationPeer : ListViewAutomationPeer
     {
     }
 
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Tree;
+
+    protected override string GetClassNameCore() => "TreeListView";
+
+    protected override List<AutomationPeer>? GetChildrenCore()
+    {
+        ItemsControl owner = (ItemsControl)Owner;
+        ItemCollection items = owner.Items;
+        List<AutomationPeer>? children = null;
+        
+        if (items.Count > 0)
+        {
+            children = new List<AutomationPeer>(items.Count);
+            for (int i = 0; i < items.Count; i++)
+            {
+                TreeListViewItem? treeViewItem = owner.ItemContainerGenerator.ContainerFromIndex(i) as TreeListViewItem;
+                //We grab top level items only
+                if (treeViewItem is { Level: 0 })
+                {
+                    children.Add(CreateItemAutomationPeer(items[i]));
+                }
+            }
+        }
+        return children;
+    }
+
     protected override ItemAutomationPeer CreateItemAutomationPeer(object item)
-        => new TreeListViewItemAutomationPeer(item, this);
+    {
+        return new TreeListViewItemAutomationPeer(item, this);
+    }
 }
 
 public class TreeListViewItemAutomationPeer : ListBoxItemAutomationPeer
@@ -17,6 +46,27 @@ public class TreeListViewItemAutomationPeer : ListBoxItemAutomationPeer
     public TreeListViewItemAutomationPeer(object owner, SelectorAutomationPeer selectorAutomationPeer)
         : base(owner, selectorAutomationPeer)
     {
+
+    }
+
+    protected override List<AutomationPeer> GetChildrenCore()
+    {
+        List<AutomationPeer> rv = base.GetChildrenCore();
+
+        if (ItemsControlAutomationPeer is TreeListViewAutomationPeer { Owner: TreeListView treeListView } itemAutomationPeer &&
+            treeListView.ItemContainerGenerator.ContainerFromItem(Item) is TreeListViewItem treeListViewItem)
+        {
+            int index = treeListView.ItemContainerGenerator.IndexFromContainer(treeListViewItem);
+            if (index >= 0)
+            {
+                foreach (int childIndex in treeListView.InternalItemsSource?.GetDirectChildrenIndexes(index) ?? Array.Empty<int>())
+                {
+                    rv.Add(new TreeListViewItemAutomationPeer(treeListView.Items[childIndex], itemAutomationPeer));
+                }
+            }
+        }
+
+        return rv;
     }
 
     public override object GetPattern(PatternInterface patternInterface)
@@ -27,4 +77,7 @@ public class TreeListViewItemAutomationPeer : ListBoxItemAutomationPeer
         }
         return base.GetPattern(patternInterface);
     }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.TreeItem;
+    protected override string GetClassNameCore() => "TreeListViewItem";
 }

--- a/MaterialDesignThemes.Wpf/Internal/TreeListViewItemsCollection.cs
+++ b/MaterialDesignThemes.Wpf/Internal/TreeListViewItemsCollection.cs
@@ -45,7 +45,7 @@ public class TreeListViewItemsCollection : ObservableCollection<object?>
 
             if (priorRootLevelItems > index)
             {
-                // We've have passed the provided index, which means we've found a non-prior root level item; bail out.
+                // We've have passed the provided index, which means we've found a non-prior root parentLevel item; bail out.
                 break;
             }
         }
@@ -65,7 +65,7 @@ public class TreeListViewItemsCollection : ObservableCollection<object?>
     {
         if (level < 0) throw new ArgumentOutOfRangeException(nameof(level), level, "Item level must not be negative");
 
-        //Always allowed to request previous item level + 1 as this is inserting a "child"
+        //Always allowed to request previous item parentLevel + 1 as this is inserting a "child"
         int previousItemLevel = index > 0 ? ItemLevels[index - 1] : -1;
         if (level > previousItemLevel + 1)
         {
@@ -98,6 +98,31 @@ public class TreeListViewItemsCollection : ObservableCollection<object?>
             }
         }
         return null;
+    }
+
+    public IEnumerable<int> GetDirectChildrenIndexes(int index)
+    {
+        if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index));
+
+        return GetDirectChildrenIndexesImplementation(index);
+
+        IEnumerable<int> GetDirectChildrenIndexesImplementation(int index)
+        {
+            int parentLevel = ItemLevels[index];
+
+            for (int i = index + 1; i < ItemLevels.Count; i++)
+            {
+                int level = ItemLevels[i];
+                if (level == parentLevel + 1)
+                {
+                    yield return i;
+                }
+                if (level <= parentLevel)
+                {
+                    yield break;
+                }
+            }
+        }
     }
 
     protected override void RemoveItem(int index)

--- a/MaterialDesignThemes.Wpf/TreeListView.cs
+++ b/MaterialDesignThemes.Wpf/TreeListView.cs
@@ -18,7 +18,7 @@ public class TreeListView : ListView
     public static readonly DependencyProperty LevelIndentSizeProperty =
         DependencyProperty.Register(nameof(LevelIndentSize), typeof(double), typeof(TreeListView), new PropertyMetadata(16.0));
 
-    private TreeListViewItemsCollection? InternalItemsSource { get; set; }
+    internal TreeListViewItemsCollection? InternalItemsSource { get; set; }
 
     static TreeListView()
     {


### PR DESCRIPTION
(#3411)

This ends up displaying nested nodes as child automation peers of their parent.