### PR TITLE
#3740 - Fix to Style MaterialDesignSwitchToggleButton

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
@@ -399,10 +399,12 @@
                                  Duration="0" />
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Width"
+                                 From="0"
                                  To="{Binding Tag, ElementName=SwitchGrid}"
                                  Duration="0" />
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Height"
+                                 From="0"
                                  To="{Binding Tag, ElementName=SwitchGrid}"
                                  Duration="0" />
               </Storyboard>


### PR DESCRIPTION
'System.Windows.Media.Animation.DoubleAnimation' cannot use default origin value of 'NaN' in UncheckedStoryboard when using DynamicResource (#3776)