### PR TITLE
Introduce AP to control IsTabStop of the reveal button in PasswordBox…

### DIFF
--- a/src/MaterialDesignThemes.Wpf/PasswordBoxAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/PasswordBoxAssist.cs
@@ -19,6 +19,11 @@ public static class PasswordBoxAssist
     public static void SetIsPasswordRevealed(DependencyObject element, bool value) => element.SetValue(IsPasswordRevealedProperty, value);
     public static bool GetIsPasswordRevealed(DependencyObject element) => (bool)element.GetValue(IsPasswordRevealedProperty);
 
+    public static readonly DependencyProperty IsRevealButtonTabStopProperty = DependencyProperty.RegisterAttached(
+        "IsRevealButtonTabStop", typeof(bool), typeof(PasswordBoxAssist), new PropertyMetadata(true));
+    public static void SetIsRevealButtonTabStop(DependencyObject element, bool value) => element.SetValue(IsRevealButtonTabStopProperty, value);
+    public static bool GetIsRevealButtonTabStop(DependencyObject element) => (bool)element.GetValue(IsRevealButtonTabStopProperty);
+
     public static readonly DependencyProperty PasswordProperty = DependencyProperty.RegisterAttached(
         "Password", typeof(string), typeof(PasswordBoxAssist), new FrameworkPropertyMetadata(null, HandlePasswordChanged) { BindsTwoWayByDefault = true, DefaultUpdateSourceTrigger = UpdateSourceTrigger.LostFocus });
     public static void SetPassword(DependencyObject element, string value) => element.SetValue(PasswordProperty, value);

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -884,6 +884,7 @@
                   <ToggleButton x:Name="RevealPasswordButton"
                                 Grid.Column="4"
                                 Height="Auto"
+                                IsTabStop="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsRevealButtonTabStop)}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Padding="2,0,0,0"
                                 VerticalAlignment="Center"

--- a/tests/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using MaterialDesignThemes.UITests.Samples.PasswordBox;
 using MaterialDesignThemes.UITests.WPF.TextBoxes;
 
@@ -330,6 +330,37 @@ public class PasswordBoxTests : TestBase
         Assert.True(await revealPasswordTextBox.GetIsKeyboardFocused());
         await revealPasswordTextBox.SendKeyboardInput($"{Key.Tab}{ModifierKeys.None}");
         Assert.True(await textBox1.GetIsKeyboardFocused());
+
+        recorder.Success();
+    }
+
+    [Fact]
+    [Description("Issue 3799")]
+    public async Task PasswordBox_WithRevealButtonIsTabStopSetToFalse_RespectsKeyboardTabNavigation()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel Orientation="Vertical">
+              <PasswordBox x:Name="PasswordBox" Width="200"
+                           materialDesign:PasswordBoxAssist.IsRevealButtonTabStop="False"
+                           Style="{StaticResource MaterialDesignFilledRevealPasswordBox}" />
+              <TextBox x:Name="TextBox" Width="200" />
+            </StackPanel>
+            """);
+
+        var passwordBox = await stackPanel.GetElement<PasswordBox>("PasswordBox");
+        var textBox = await stackPanel.GetElement<TextBox>("TextBox");
+
+        // Assert Tab forward
+        await passwordBox.MoveKeyboardFocus();
+        Assert.True(await passwordBox.GetIsKeyboardFocused());
+        await passwordBox.SendKeyboardInput($"{Key.Tab}");
+        Assert.True(await textBox.GetIsKeyboardFocused());
+        
+        // Assert Tab backwards
+        await textBox.SendKeyboardInput($"{ModifierKeys.Shift}{Key.Tab}{ModifierKeys.None}");
+        Assert.True(await passwordBox.GetIsKeyboardFocused());
 
         recorder.Success();
     }


### PR DESCRIPTION
… (reveal style) (#3800)

* Add failing unit test

* Add AP allowing control of IsTabStop of the reveal button

* Fix test by applying new AP

* Removing the inherits since it does not appear to be needed.

---------