### PR TITLE
fix(card): remove duplicate padding in card style (#4009)

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -83,7 +83,6 @@
                     Background="{TemplateBinding Background}"
                     Clip="{TemplateBinding ContentClip}">
               <ContentPresenter x:Name="ContentPresenter"
-                                Margin="{TemplateBinding Padding}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Content="{TemplateBinding ContentControl.Content}"


### PR DESCRIPTION
The Padding was applied once through the Borders Padding and once more by the ContentPresenters Margin, effectively doubling the Paddings value specified on the call-site.