### PR TITLE
Avoid queuing not-needed AP updates (#4024)

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Threading;
+﻿using System.Threading;
+using System.Windows.Threading;
 using Microsoft.Xaml.Behaviors;
 
 namespace MaterialDesignThemes.Wpf.Behaviors;
@@ -11,18 +12,22 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
     private void AssociatedObjectOnTextChanged(object sender, TextChangedEventArgs e) => UpdateAttachedProperties();
     private void AssociatedObjectOnLayoutUpdated(object? sender, EventArgs e) => UpdateAttachedProperties();
 
+    private int _uiUpdateInProgress = 0;
+
     private void UpdateAttachedProperties()
     {
-        if (AssociatedObject is { } associatedObject)
+        if (AssociatedObject is { } associatedObject &&
+            Interlocked.CompareExchange(ref _uiUpdateInProgress, 1, 0) == 0)
         {
             associatedObject.Dispatcher
-                .BeginInvoke(() =>
-                {
-                    int lineCount = associatedObject.LineCount;
-                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, lineCount);
-                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, lineCount > 1);
-                },
-                DispatcherPriority.Background);
+            .BeginInvoke(() =>
+            {
+                int lineCount = associatedObject.LineCount;
+                associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, lineCount);
+                associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, lineCount > 1);
+                Interlocked.CompareExchange(ref _uiUpdateInProgress, 0, 1);
+            },
+            DispatcherPriority.Background);
         }
     }
 
@@ -35,10 +40,10 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
 
     protected override void OnDetaching()
     {
-        if (AssociatedObject != null)
+        if (AssociatedObject is { } associatedObject)
         {
-            AssociatedObject.TextChanged -= AssociatedObjectOnTextChanged;
-            AssociatedObject.LayoutUpdated -= AssociatedObjectOnLayoutUpdated;
+            associatedObject.TextChanged -= AssociatedObjectOnTextChanged;
+            associatedObject.LayoutUpdated -= AssociatedObjectOnLayoutUpdated;
         }
         base.OnDetaching();
     }


### PR DESCRIPTION
If an update has already been queued for processing (but not yet completed), simply skip queuing another update.