### PR TITLE
fix(TabControl): Apply ColorZoneAssist properties to TabItems (#4071)

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:convertersInternal="clr-namespace:MaterialDesignThemes.Wpf.Converters.Internal"
@@ -781,6 +781,9 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
+    <Setter Property="wpf:ColorZoneAssist.Background" Value="Transparent" />
+    <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(wpf:ColorZoneAssist.Foreground), FallbackValue=Black}" />
+    <Setter Property="wpf:ColorZoneAssist.Mode" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(wpf:ColorZoneAssist.Mode), FallbackValue=Standard}" />
     <Setter Property="Width" Value="72" />
     <Setter Property="wpf:DialogHost.RestoreFocusElement" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=TabControl}}" />
     <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesign.Brush.Button.Ripple}" />


### PR DESCRIPTION
Ensures TabItems within a TabControl correctly adopt the parent's ColorZoneAssist.Background, Foreground, and Mode properties. This resolves styling inconsistencies when a TabControl is used within a ColorZone.

Fixes #3962